### PR TITLE
Player RGBA

### DIFF
--- a/settings/ESP.kts
+++ b/settings/ESP.kts
@@ -88,12 +88,12 @@ SHOW_GRENADES = false
 /**
  * The color to highlight your team mates.
  */
-TEAM_COLOR = Color(0, 0, 255)
+TEAM_COLOR = Color(0, 0, 255, 1.0)
 
 /**
  * The color to highlight your enemies.
  */
-ENEMY_COLOR = Color(255, 0, 0)
+ENEMY_COLOR = Color(255, 0, 0, 1.0)
 
 /**
  * The color to highlight the bomb.

--- a/src/main/kotlin/com/charlatano/settings/ESP.kt
+++ b/src/main/kotlin/com/charlatano/settings/ESP.kt
@@ -87,12 +87,12 @@ var SHOW_GRENADES = false
 /**
  * The color to highlight your team mates.
  */
-var TEAM_COLOR = Color(0, 0, 255)
+var TEAM_COLOR = Color(0, 0, 255, 1.0)
 
 /**
  * The color to highlight your enemies.
  */
-var ENEMY_COLOR = Color(255, 0, 0)
+var ENEMY_COLOR = Color(255, 0, 0, 1.0)
 
 /**
  * The color to highlight the bomb.


### PR DESCRIPTION
Allows users to change the alpha of the player and enemy glow, just like weapon , grenade, and bomb glow. Not very useful, but nice if you want a _calmer_ or **stronger** glow.