### PR TITLE
Hazedumper like syntax for module patterns

### DIFF
--- a/src/main/kotlin/com/charlatano/game/offsets/ModuleScan.kt
+++ b/src/main/kotlin/com/charlatano/game/offsets/ModuleScan.kt
@@ -32,6 +32,15 @@ internal class ModuleScan(private val module: Module, private val patternOffset:
 		for (flag in mask) when (flag) {
 			is Number -> bytes.add(flag.toByte())
 			is RepeatedInt -> repeat(flag.repeats) { bytes.add(flag.value.toByte()) }
+			is String -> {
+			    flag.split(" ").forEach {
+			    if (it.trim() == "?") {
+				bytes.add(0.toByte())
+			    } else {
+				bytes.add(it.toInt(16).toByte())
+			    }
+			}
+		    }
 		}
 		
 		return Offset(module, patternOffset, addressOffset, read, subtract, bytes.toByteArray())


### PR DESCRIPTION
So https://github.com/Jire/Charlatano/blob/f29661080bba91223ee5d6cf28a0cd19eb2b5b8c/src/main/kotlin/com/charlatano/game/offsets/ClientOffsets.kt#L76 can actually works.

Merging 2 similar code bases is not easy 😄 