### PR TITLE
Updated GlowESP.kt with easy to see fake chams

### DIFF
--- a/src/main/kotlin/com/charlatano/scripts/esp/GlowESP.kt
+++ b/src/main/kotlin/com/charlatano/scripts/esp/GlowESP.kt
@@ -70,6 +70,8 @@ private fun Entity.glow(color: Color) {
 	csgoEXE[this + 0x8] = color.green / 255F
 	csgoEXE[this + 0xC] = color.blue / 255F
 	csgoEXE[this + 0x10] = color.alpha.toFloat()
+	//Fake chams glows players only when visible and only glows on body, aka the body is a glow mask.
+	//csgoEXE[this + 0x2C] = true
 	csgoEXE[this + 0x24] = true
 }
 


### PR DESCRIPTION
This is a combined attempt to adding chams to Charlatano.
I contacted RizeyFox#6122 about his chams version and found out it was a fake cham.
Tried messing around and this is the best i could get.
I hope someone takes this one line of code and makes a great cham out of it for the main branch.
Picture: https://i.imgur.com/3dMyVva.png
No glow is visible behind walls since the glow is rendered on the model.

Another way of implementing chams is to fullbright the "chams" underneath.
That way you can actually see them colored instead of the models being really dark.